### PR TITLE
track updated_at property in state

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -149,7 +149,7 @@ export default class Main extends Component {
         <ExtensionUI
           disablePreviewOpen={!!contentSyncUrl}
           contentSlug={contentSlug || initalValue}
-          previewUrl={this.getPreviewUrl}
+          previewUrl={this.getPreviewUrl()}
           authToken={authToken}
           onOpenPreviewButtonClick={
             contentSyncUrl

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -76,8 +76,8 @@ export default class Main extends Component {
   }
 
   componentWillUnmount() {
-    const { slugField, updatedAt } = this.state;
-    if (slugField || updatedAt) {
+    const { slugField } = this.state;
+    if (slugField) {
       this.unsubscribe();
     }
   }


### PR DESCRIPTION
`componentDidUpdate` was often firing after the preview URL value was already set. By tracking `updatedAt` as part of the state object, we can more consistently update the preview URL when content is updated. 