### PR TITLE
feat: add eager redirects support

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -103,12 +103,14 @@ export default class Main extends Component {
       parameters: {
         global: { instanceUrl, contentSyncUrl },
       },
+      itemType: { type },
+      itemId,
     } = plugin;
     const manifestId = this.getManifestId();
 
     let previewUrl = instanceUrl;
     if (contentSyncUrl && manifestId) {
-      previewUrl = `${contentSyncUrl}/gatsby-source-datocms/${manifestId}`;
+      previewUrl = `${contentSyncUrl}/gatsby-source-datocms/${manifestId}/${type}-${itemId}`;
     }
 
     return previewUrl;


### PR DESCRIPTION
This PR adds support for "eager redirects" which is a new feature of [Content Sync (Gatsby Preview)](https://www.gatsbyjs.com/docs/conceptual/content-sync/).

Eager Redirects is a Content Sync feature which causes the user to be redirected to their site front-end as soon as possible. When they first preview a piece of content, they will stay in the Content Sync loading screen until their preview is ready. On subsequent previews of that same piece of content, they will be redirected as soon as the page loads. This is done by storing a “content ID” in local storage. The content ID should be a unique identifier for that piece of content which is consistent across all previews.
